### PR TITLE
Carregamento da Cidade após inclusão de um cliente

### DIFF
--- a/Trino.WPF.ProjetoFinal/Trino.WPF.ProjetoFinal.Data/App.Config
+++ b/Trino.WPF.ProjetoFinal/Trino.WPF.ProjetoFinal.Data/App.Config
@@ -4,7 +4,9 @@
     <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
     <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
   </configSections>
-  <connectionStrings><add name="TrinoProjetoFinalDBEntities" connectionString="metadata=res://*/FinalProjectDBModel.csdl|res://*/FinalProjectDBModel.ssdl|res://*/FinalProjectDBModel.msl;provider=System.Data.SqlClient;provider connection string=&quot;data source=vjmaurinnote\SQLEXPRESS;initial catalog=TrinoProjetoFinalDB;integrated security=True;MultipleActiveResultSets=True;App=EntityFramework&quot;" providerName="System.Data.EntityClient" /><add name="TrinoProjetoFinalDBEntities" connectionString="metadata=res://*/FinalProjectDBModel.csdl|res://*/FinalProjectDBModel.ssdl|res://*/FinalProjectDBModel.msl;provider=System.Data.SqlClient;provider connection string=&quot;data source=vjmaurinnote\SQLEXPRESS;initial catalog=TrinoProjetoFinalDB;integrated security=True;MultipleActiveResultSets=True;App=EntityFramework&quot;" providerName="System.Data.EntityClient" /></connectionStrings>
+  <connectionStrings>
+    <add name="TrinoProjetoFinalDBEntities" connectionString="metadata=res://*/FinalProjectDBModel.csdl|res://*/FinalProjectDBModel.ssdl|res://*/FinalProjectDBModel.msl;provider=System.Data.SqlClient;provider connection string=&quot;data source=danielnote\SQLEXPRESS;initial catalog=FinalProjectDB;integrated security=True;MultipleActiveResultSets=True;App=EntityFramework&quot;" providerName="System.Data.EntityClient" />
+  </connectionStrings>
   <entityFramework>
     <defaultConnectionFactory type="System.Data.Entity.Infrastructure.SqlConnectionFactory, EntityFramework" />
     <providers>

--- a/Trino.WPF.ProjetoFinal/Trino.WPF.ProjetoFinal.Data/Repositorios/ClienteRepositorio.cs
+++ b/Trino.WPF.ProjetoFinal/Trino.WPF.ProjetoFinal.Data/Repositorios/ClienteRepositorio.cs
@@ -1,8 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Trino.WPF.ProjetoFinal.Data.Repositorios.Interface;
 
 namespace Trino.WPF.ProjetoFinal.Data.Repositorios
@@ -24,7 +21,7 @@ namespace Trino.WPF.ProjetoFinal.Data.Repositorios
 
         public IEnumerable<Customer> Get()
         {
-            return this._context.Customers;
+            return this._context.Customers.Include("City");
         }
 
         public void Inserir(Customer cliente)

--- a/Trino.WPF.ProjetoFinal/Trino.WPF.ProjetoFinal.Data/Repositorios/ClienteRepositorio.cs
+++ b/Trino.WPF.ProjetoFinal/Trino.WPF.ProjetoFinal.Data/Repositorios/ClienteRepositorio.cs
@@ -32,6 +32,7 @@ namespace Trino.WPF.ProjetoFinal.Data.Repositorios
             if (cliente.Id == Guid.Empty)
                 cliente.Id = Guid.NewGuid();
 
+
             this._context.Customers.Add(cliente);
             this._context.SaveChanges();
         }

--- a/Trino.WPF.ProjetoFinal/Trino.WPF.ProjetoFinal/App.config
+++ b/Trino.WPF.ProjetoFinal/Trino.WPF.ProjetoFinal/App.config
@@ -5,7 +5,7 @@
     <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
   </configSections>
   <connectionStrings>
-    <add name="TrinoProjetoFinalDBEntities" connectionString="metadata=res://*/FinalProjectDBModel.csdl|res://*/FinalProjectDBModel.ssdl|res://*/FinalProjectDBModel.msl;provider=System.Data.SqlClient;provider connection string=&quot;data source=vjmaurinnote\SQLEXPRESS;initial catalog=TrinoProjetoFinalDB;integrated security=True;MultipleActiveResultSets=True;App=EntityFramework&quot;" providerName="System.Data.EntityClient" />
+    <add name="TrinoProjetoFinalDBEntities" connectionString="metadata=res://*/FinalProjectDBModel.csdl|res://*/FinalProjectDBModel.ssdl|res://*/FinalProjectDBModel.msl;provider=System.Data.SqlClient;provider connection string=&quot;data source=danielnote\SQLEXPRESS;initial catalog=FinalProjectDB;integrated security=True;MultipleActiveResultSets=True;App=EntityFramework&quot;" providerName="System.Data.EntityClient" />
   </connectionStrings>
   <entityFramework>
     <defaultConnectionFactory type="System.Data.Entity.Infrastructure.SqlConnectionFactory, EntityFramework" />


### PR DESCRIPTION
Sempre que você utiliza apenas um context no repositório é necessário que você informe ao context que será necessário carregar uma propriedade que faz relação com outra tabela no banco de dados.

O parâmetro **include** faz exatamente isso.